### PR TITLE
fix(rules): no empty line before unspecified properties for the order

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -219,8 +219,7 @@ module.exports = {
 				...recessOrder.rules['order/properties-order'],
 			],
 			{
-				emptyLineBeforeUnspecified: 'always',
-				unspecified:                'bottomAlphabetical',
+				unspecified: 'bottomAlphabetical',
 			},
 		],
 		'order/properties-alphabetical-order': null,


### PR DESCRIPTION
way too generic and conflicts with declaration-empty-line-before: never in too many ways